### PR TITLE
Support 'resources' folder

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -17,7 +17,7 @@ const WINDOWS_NEWLINE_LENGTH = 2;
 
 const CONFIG_REGEX = /\/(config|schemas)\//;
 const APP_SCRIPT_REGEX =
-  /\/applications\/\w+\/(api|www|tasks|init|setup|model|lib)\//;
+  /\/applications\/\w+\/(api|www|tasks|init|setup|model|resources|lib)\//;
 
 const USE_STRICT = '\'use strict\';\n';
 


### PR DESCRIPTION
With the recent changes in https://github.com/metarhia/impress/pull/935
the resources folder now also contains scripts that must be modified for
ESlint.

~~I can put 'model' back if needed for backward compatibility.~~

Edit: Model folder has been put back.